### PR TITLE
Compiling with Intel 2021

### DIFF
--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -26,6 +26,13 @@ add_library(HCOX STATIC EXCLUDE_FROM_ALL
 	hcox_volcano_mod.F90
 	ocean_toolbox_mod.F90
 )
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+    set_source_files_properties(
+        hcox_dustdead_mod.F
+        $<$<BOOL:${TOMAS}>:hcox_tomas_dustdead_mod.F>
+        PROPERTIES COMPILE_FLAGS "-fixed"
+    )
+endif()
 target_link_libraries(HCOX
 	PUBLIC HCO
 )


### PR DESCRIPTION
I tried building GISS-GC on one of our local systems with the Intel 2021.6.0 compiler and found that it didn't like some of the Fortran 77 code. To fix this, I selectively applied the `-fixed` compiler flag for files that were in fixed format.

Linked PRs:
https://github.com/fetch4/GISS-GC/pull/3
https://github.com/fetch4/geos-chem/pull/3
